### PR TITLE
Pz/add support for TNxPB-004

### DIFF
--- a/src/libmaxtouch/usb/usb_device.c
+++ b/src/libmaxtouch/usb/usb_device.c
@@ -398,7 +398,8 @@ static int usb_scan_for_control_if(struct mxt_device *mxt,
   int j, k, ret;
   char buf[128];
   const char control_if_mxt[] = "Atmel maXTouch Control";
-  const char control_if_tnx[] = "TNxPB-004 Digitizer Control";
+  const char control_if_tnx1[] = "TNxPB-004 Digitizer Control";
+  const char control_if_tnx2[] = "TNxPB-002 Digitizer Control";
   const char bootloader_if[] = "Atmel maXTouch Bootloader";
 
   for (j = 0; j < config->bNumInterfaces; j++) {
@@ -419,7 +420,7 @@ static int usb_scan_for_control_if(struct mxt_device *mxt,
 	    mxt->usb.ep1_in_use_max_packet_size = false;
 	    mxt->usb.request_ep = ENDPOINT_2_OUT;
             return MXT_SUCCESS;
-	  } else if (!strncmp(buf, control_if_tnx, sizeof(control_if_tnx))) {
+	  } else if (!strncmp(buf, control_if_tnx1, sizeof(control_if_tnx1))) {
             mxt_dbg(mxt->ctx, "Found %s at interface %d altsetting %d",
                     buf, altsetting->bInterfaceNumber, altsetting->bAlternateSetting);
 
@@ -427,6 +428,15 @@ static int usb_scan_for_control_if(struct mxt_device *mxt,
             mxt->usb.interface = altsetting->bInterfaceNumber;
 	    mxt->usb.ep1_in_use_max_packet_size = true;
 	    mxt->usb.request_ep = ENDPOINT_1_OUT;
+            return MXT_SUCCESS;
+	  } else if (!strncmp(buf, control_if_tnx2, sizeof(control_if_tnx2))) {
+            mxt_dbg(mxt->ctx, "Found %s at interface %d altsetting %d",
+                    buf, altsetting->bInterfaceNumber, altsetting->bAlternateSetting);
+
+            mxt->usb.bootloader = false;
+            mxt->usb.interface = altsetting->bInterfaceNumber;
+	    mxt->usb.ep1_in_use_max_packet_size = true;
+	    mxt->usb.request_ep = ENDPOINT_2_OUT;
             return MXT_SUCCESS;
           } else if (!strncmp(buf, bootloader_if, sizeof(bootloader_if))) {
             mxt_dbg(mxt->ctx, "Found %s at interface %d altsetting %d",

--- a/src/libmaxtouch/usb/usb_device.c
+++ b/src/libmaxtouch/usb/usb_device.c
@@ -462,10 +462,6 @@ static int usb_scan_device_configs(struct mxt_device *mxt)
 {
   int i, ret;
 
-  if (mxt->usb.bridge_chip && mxt->usb.desc.bNumConfigurations == 1) {
-    return usb_scan_for_qrg_if(mxt);
-  }
-
   /* Scan through interfaces */
   for (i = 0; i < mxt->usb.desc.bNumConfigurations; ++i) {
     struct libusb_config_descriptor *config;
@@ -479,6 +475,10 @@ static int usb_scan_device_configs(struct mxt_device *mxt)
         // Found interface number
         return ret;
     }
+  }
+
+  if (mxt->usb.bridge_chip && mxt->usb.desc.bNumConfigurations == 1) {
+    return usb_scan_for_qrg_if(mxt);
   }
 
   return MXT_ERROR_NO_DEVICE;

--- a/src/libmaxtouch/usb/usb_device.h
+++ b/src/libmaxtouch/usb/usb_device.h
@@ -58,6 +58,7 @@ struct usb_device {
   libusb_device_handle *handle;
   struct libusb_device_descriptor desc;
   int ep1_in_max_packet_size;
+  bool ep1_in_use_max_packet_size;
   int request_ep;
   int interface;
   bool bootloader;

--- a/src/libmaxtouch/usb/usb_device.h
+++ b/src/libmaxtouch/usb/usb_device.h
@@ -58,6 +58,7 @@ struct usb_device {
   libusb_device_handle *handle;
   struct libusb_device_descriptor desc;
   int ep1_in_max_packet_size;
+  int request_ep;
   int interface;
   bool bootloader;
   int report_id;


### PR DESCRIPTION
This enables mxt-app functionality for the TouchNetix Device PB-004.

- Full max package size must be transferred.
- Interrupt endpoint must be used instead of bulk endpoint.
- Product IDs must match (there would be more but 0x2f02 is the current one used)
